### PR TITLE
Release 1.1.3 - Updated dependencies to latest due to security vulnerability warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Please consult the chart and use the latest library version for the Spigot versi
 | 1.1.0         | 1.17.1                   | Changed to Java 16 and 1.17.1 Spigot            |
 | 1.1.1         | 1.17.1                   | Changed the way menu interaction works          |
 | 1.1.2         | 1.18.2/1.19              | Change to Java 17. Support for 1.18.2 and 1.19. |
+| 1.1.3         | 1.20.1                   | Update dependencies and support for 1.20.1.     |
 
 ## Installation
 This library runs on Maven for compilation, so we recommend using our remote Maven repository to prevent having to clone from 
@@ -27,8 +28,7 @@ First, add our remote repository which stores all of our artifacts:
 ```
 <repository>
     <id>harieo-repo</id>
-    <name>Releases</name>
-    <url>http://repo.harieo.net/repository/maven-releases</url>
+    <url>https://repo.harieo.net/repository/maven-releases</url>
 </repository>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.co.harieo</groupId>
     <artifactId>ConvenienceLib</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -25,13 +25,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>4.2.3</version>
+            <version>4.4.3</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 main: uk.co.harieo.ConvenienceLib.ConvenienceLib
-version: 1.1.2
+version: 1.1.3
 name: ConvenienceLib
 author: Harieo
-api-version: 1.19
+api-version: 1.20


### PR DESCRIPTION
- Update to Jedis 4.4.3 which has resolved several security vulnerabilities since the previous version used
- Update to Spigot 1.20.1
- Change to version 1.1.3 for minor update